### PR TITLE
docs(README): update README to reflect alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
-# lob_elixir
+# lob_elixir (alpha)
 
-Elixir Wrapper for Lob API
+Elixir Library for [Lob API](https://lob.com/)
+
+### This is an ALPHA library for the Lob API.
+
+### Please reach out to support@lob.com for assistance if planning to implement this library.
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `lob_elixir` to your list of dependencies in `mix.exs`:
+The package is currently not available in Hex. Installation should reference the library repository.
 
 ```elixir
 def deps do
   [
-    {:lob_elixir, "~> 0.1.0"}
+    {:lob_elixir, git: "https://github.com/lob/lob-elixir", tag: "v0.1.0"}
   ]
 end
 ```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/lob_elixir](https://hexdocs.pm/lob_elixir).


### PR DESCRIPTION
## Context
As discussed, the first step in releasing the Elixir library is to publicize the repo in an alpha state.

## What
- [x] Updates `README.md` to reflect alpha

## Up Next
- [x] Cut version `v0.1.0`, generate a `CHANGELOG`
- [x] Publicize repo
- [x] Create hex package