### PR TITLE
fix(base-resource): fix api url bug

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,3 @@
 use Mix.Config
 
-config :lob_elixir,
-  api_endpoint: "https://api.lob.com/v1"
-
 import_config "#{Mix.env}.exs"

--- a/lib/lob/resource_base.ex
+++ b/lib/lob/resource_base.ex
@@ -8,6 +8,8 @@ defmodule Lob.ResourceBase do
     methods = Keyword.fetch!(opts, :methods)
 
     quote do
+      @api_url "https://api.lob.com/v1"
+
       alias Lob.Util
       alias Lob.Client
 
@@ -40,7 +42,7 @@ defmodule Lob.ResourceBase do
       end
 
       @spec base_url :: String.t
-      defp base_url, do: "#{Application.get_env(:lob_elixir, :api_endpoint)}/#{unquote(endpoint)}"
+      defp base_url, do: "#{@api_url}/#{unquote(endpoint)}"
 
       @spec resource_url(String.t) :: String.t
       defp resource_url(resource_id), do: "#{base_url()}/#{resource_id}"


### PR DESCRIPTION
## Context
Upon further research and experimentation, I realized that Mix will ignore any configuration scripts from the dependencies. That means that when an application includes `lob_elixir` as a dependency Mix will ignore `lob_elixir`'s configs, including `:api_endpoint`.

## What
- [x] Configures the base API url in `Lob.ResourceBase` instead of through configs.