### PR TITLE
feat(bang-methods): add bang methods to resource base module

### DIFF
--- a/lib/lob/resource_base.ex
+++ b/lib/lob/resource_base.ex
@@ -19,7 +19,7 @@ defmodule Lob.ResourceBase do
           Client.get_request("#{base_url()}?#{Util.build_query_string(params)}" , Util.build_headers(headers))
         end
 
-        @spec list!(map, map) :: {map, list}
+        @spec list!(map, map) :: {map, list} | no_return
         def list!(params \\ %{}, headers \\ %{}) do
           case list(params, headers) do
             {:ok, body, headers} -> {body, headers}
@@ -34,7 +34,7 @@ defmodule Lob.ResourceBase do
           Client.get_request(resource_url(id), Util.build_headers(headers))
         end
 
-        @spec retrieve!(String.t, map) :: {map, list}
+        @spec retrieve!(String.t, map) :: {map, list} | no_return
         def retrieve!(id, headers \\ %{}) do
           case retrieve(id, headers) do
             {:ok, body, headers} -> {body, headers}
@@ -49,7 +49,7 @@ defmodule Lob.ResourceBase do
           Client.post_request(base_url(), Util.build_body(data), Util.build_headers(headers))
         end
 
-        @spec create!(map, map) :: {map, list}
+        @spec create!(map, map) :: {map, list} | no_return
         def create!(data, headers \\ %{}) do
           case create(data, headers) do
             {:ok, body, headers} -> {body, headers}
@@ -64,7 +64,7 @@ defmodule Lob.ResourceBase do
           Client.delete_request(resource_url(id), Util.build_headers(headers))
         end
 
-        @spec delete!(String.t, map) :: {map, list}
+        @spec delete!(String.t, map) :: {map, list} | no_return
         def delete!(id, headers \\ %{}) do
           case delete(id, headers) do
             {:ok, body, headers} -> {body, headers}

--- a/lib/lob/resource_base.ex
+++ b/lib/lob/resource_base.ex
@@ -18,12 +18,28 @@ defmodule Lob.ResourceBase do
         def list(params \\ %{}, headers \\ %{}) do
           Client.get_request("#{base_url()}?#{Util.build_query_string(params)}" , Util.build_headers(headers))
         end
+
+        @spec list!(map, map) :: {map, list}
+        def list!(params \\ %{}, headers \\ %{}) do
+          case list(params, headers) do
+            {:ok, body, headers} -> {body, headers}
+            error -> raise to_string(error)
+          end
+        end
       end
 
       if :retrieve in unquote(methods) do
         @spec retrieve(String.t, map) :: Client.response
         def retrieve(id, headers \\ %{}) do
           Client.get_request(resource_url(id), Util.build_headers(headers))
+        end
+
+        @spec retrieve!(map, map) :: {map, list}
+        def retrieve!(id \\ %{}, headers \\ %{}) do
+          case retrieve(id, headers) do
+            {:ok, body, headers} -> {body, headers}
+            error -> raise to_string(error)
+          end
         end
       end
 
@@ -32,12 +48,28 @@ defmodule Lob.ResourceBase do
         def create(data, headers \\ %{}) do
           Client.post_request(base_url(), Util.build_body(data), Util.build_headers(headers))
         end
+
+        @spec create!(map, map) :: {map, list}
+        def create!(data \\ %{}, headers \\ %{}) do
+          case create(data, headers) do
+            {:ok, body, headers} -> {body, headers}
+            error -> raise to_string(error)
+          end
+        end
       end
 
       if :delete in unquote(methods) do
         @spec delete(String.t, map) :: Client.response
         def delete(id, headers \\ %{}) do
           Client.delete_request(resource_url(id), Util.build_headers(headers))
+        end
+
+        @spec delete!(map, map) :: {map, list}
+        def delete!(id \\ %{}, headers \\ %{}) do
+          case delete(id, headers) do
+            {:ok, body, headers} -> {body, headers}
+            error -> raise to_string(error)
+          end
         end
       end
 

--- a/lib/lob/resource_base.ex
+++ b/lib/lob/resource_base.ex
@@ -19,7 +19,6 @@ defmodule Lob.ResourceBase do
           Client.get_request("#{base_url()}?#{Util.build_query_string(params)}" , Util.build_headers(headers))
         end
 
-        @spec list!(map, map) :: {map, list}
         def list!(params \\ %{}, headers \\ %{}) do
           case list(params, headers) do
             {:ok, body, headers} -> {body, headers}
@@ -34,7 +33,6 @@ defmodule Lob.ResourceBase do
           Client.get_request(resource_url(id), Util.build_headers(headers))
         end
 
-        @spec retrieve!(map, map) :: {map, list}
         def retrieve!(id \\ %{}, headers \\ %{}) do
           case retrieve(id, headers) do
             {:ok, body, headers} -> {body, headers}
@@ -49,7 +47,6 @@ defmodule Lob.ResourceBase do
           Client.post_request(base_url(), Util.build_body(data), Util.build_headers(headers))
         end
 
-        @spec create!(map, map) :: {map, list}
         def create!(data \\ %{}, headers \\ %{}) do
           case create(data, headers) do
             {:ok, body, headers} -> {body, headers}
@@ -64,7 +61,6 @@ defmodule Lob.ResourceBase do
           Client.delete_request(resource_url(id), Util.build_headers(headers))
         end
 
-        @spec delete!(map, map) :: {map, list}
         def delete!(id \\ %{}, headers \\ %{}) do
           case delete(id, headers) do
             {:ok, body, headers} -> {body, headers}

--- a/lib/lob/resource_base.ex
+++ b/lib/lob/resource_base.ex
@@ -23,7 +23,7 @@ defmodule Lob.ResourceBase do
         def list!(params \\ %{}, headers \\ %{}) do
           case list(params, headers) do
             {:ok, body, headers} -> {body, headers}
-            error -> raise to_string(error)
+            {:error, error} -> raise to_string(error)
           end
         end
       end
@@ -38,7 +38,7 @@ defmodule Lob.ResourceBase do
         def retrieve!(id, headers \\ %{}) do
           case retrieve(id, headers) do
             {:ok, body, headers} -> {body, headers}
-            error -> raise to_string(error)
+            {:error, error} -> raise to_string(error)
           end
         end
       end
@@ -49,11 +49,11 @@ defmodule Lob.ResourceBase do
           Client.post_request(base_url(), Util.build_body(data), Util.build_headers(headers))
         end
 
-        @spec create!(String.t, map) :: {map, list}
+        @spec create!(map, map) :: {map, list}
         def create!(data, headers \\ %{}) do
           case create(data, headers) do
             {:ok, body, headers} -> {body, headers}
-            error -> raise to_string(error)
+            {:error, error} -> raise to_string(error)
           end
         end
       end
@@ -68,7 +68,7 @@ defmodule Lob.ResourceBase do
         def delete!(id, headers \\ %{}) do
           case delete(id, headers) do
             {:ok, body, headers} -> {body, headers}
-            error -> raise to_string(error)
+            {:error, error} -> raise to_string(error)
           end
         end
       end

--- a/lib/lob/resource_base.ex
+++ b/lib/lob/resource_base.ex
@@ -19,6 +19,7 @@ defmodule Lob.ResourceBase do
           Client.get_request("#{base_url()}?#{Util.build_query_string(params)}" , Util.build_headers(headers))
         end
 
+        @spec list!(map, map) :: {map, list}
         def list!(params \\ %{}, headers \\ %{}) do
           case list(params, headers) do
             {:ok, body, headers} -> {body, headers}
@@ -33,7 +34,8 @@ defmodule Lob.ResourceBase do
           Client.get_request(resource_url(id), Util.build_headers(headers))
         end
 
-        def retrieve!(id \\ %{}, headers \\ %{}) do
+        @spec retrieve!(String.t, map) :: {map, list}
+        def retrieve!(id, headers \\ %{}) do
           case retrieve(id, headers) do
             {:ok, body, headers} -> {body, headers}
             error -> raise to_string(error)
@@ -47,7 +49,8 @@ defmodule Lob.ResourceBase do
           Client.post_request(base_url(), Util.build_body(data), Util.build_headers(headers))
         end
 
-        def create!(data \\ %{}, headers \\ %{}) do
+        @spec create!(String.t, map) :: {map, list}
+        def create!(data, headers \\ %{}) do
           case create(data, headers) do
             {:ok, body, headers} -> {body, headers}
             error -> raise to_string(error)
@@ -61,7 +64,8 @@ defmodule Lob.ResourceBase do
           Client.delete_request(resource_url(id), Util.build_headers(headers))
         end
 
-        def delete!(id \\ %{}, headers \\ %{}) do
+        @spec delete!(String.t, map) :: {map, list}
+        def delete!(id, headers \\ %{}) do
           case delete(id, headers) do
             {:ok, body, headers} -> {body, headers}
             error -> raise to_string(error)

--- a/lib/lob/util.ex
+++ b/lib/lob/util.ex
@@ -38,7 +38,7 @@ defmodule Lob.Util do
     iex> Lob.Util.build_headers(%{"Idempotency-Key" => "abc123", "Lob-Version" => "2017-11-08"})
     [{"Idempotency-Key", "abc123"}, {"Lob-Version", "2017-11-08"}]
   """
-  @spec build_headers(list({any, any})) :: HTTPoison.Base.headers
+  @spec build_headers(map) :: HTTPoison.Base.headers
   def build_headers(headers) do
     headers
     |> Enum.to_list


### PR DESCRIPTION
## What

Adds `list!/2`, `retrieve!/2`, `create!/2` and `delete!/2` methods to resource base.

## Why

To follow the Elixir package conventions of having methods with [a trailing bang](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/pages/Naming%20Conventions.md#trailing-bang-foo).

## Note

I haven't thought of the best way to add tests for these new methods. Adding tests to every resource might be a bit cumbersome, but I'm open to doing that.