### PR TITLE
feat(client): removes HTTP response timeout

### DIFF
--- a/lib/lob/client.ex
+++ b/lib/lob/client.ex
@@ -101,7 +101,7 @@ defmodule Lob.Client do
 
   @spec build_options(String.t) :: Keyword.t
   defp build_options(api_key \\ api_key()) do
-    [hackney: [basic_auth: {api_key, ""}]]
+    [hackney: [basic_auth: {api_key, ""}], recv_timeout: :infinity]
   end
 
   @spec default_headers(String.t | nil) :: %{String.t => String.t}


### PR DESCRIPTION
## What
- [x] Sets `:recv_timeout` to infinity

## Why
`:recv_timeout` corresponds to the [timeout for the HTTP response](https://hexdocs.pm/httpoison/HTTPoison.Request.html). The default is 5 seconds. In some cases Lob API will respond in more than 5 seconds, so we don't want the client to terminate the request.

I've opted to set it to infinity in order to defer to API for timeout errors. The API has a timeout of around 60s, which will return a 4XX type error to the client.