### PR TITLE
Relax httpoison requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Lob.Mixfile do
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5.1", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.7.4", only: :test},
-      {:httpoison, "~> 0.13"},
+      {:httpoison, ">= 0.13.0"},
       {:poison, "~> 3.1"},
       {:uuid, "~> 1.1", only: :test}
     ]


### PR DESCRIPTION
This sets a minimum requirement for httpoison - currently it's at v1.5.