### PR TITLE
Replace HTTPoison.Base due to conflict with response type

### DIFF
--- a/lib/lob/client.ex
+++ b/lib/lob/client.ex
@@ -7,8 +7,6 @@ defmodule Lob.Client do
   alias HTTPoison.Error
   alias HTTPoison.Response
 
-  use HTTPoison.Base
-
   @client_version Mix.Project.config[:version]
 
   @type response :: {:ok, map, list} | {:error, map}
@@ -42,43 +40,35 @@ defmodule Lob.Client do
   def api_version, do: Application.get_env(:lob_elixir, :api_version, System.get_env("LOB_API_VERSION"))
 
   # #########################
-  # HTTPoison.Base callbacks
-  # #########################
-
-  def process_request_headers(headers) do
-    api_version()
-    |> default_headers()
-    |> Map.merge(Map.new(headers))
-    |> Enum.into([])
-  end
-
-  def process_response_body(body) do
-    Parser.parse!(body, keys: :atoms)
-  end
-
-  # #########################
   # Client API
   # #########################
 
   @spec get_request(String.t, HTTPoison.Base.headers) :: response
   def get_request(url, headers \\ []) do
     url
-    |> get(headers, build_options())
+    |> HTTPoison.get(process_request_headers(headers), build_options())
     |> handle_response
   end
 
   @spec post_request(String.t, {:multipart, list}, HTTPoison.Base.headers) :: response
   def post_request(url, body, headers \\ []) do
     url
-    |> post(body, headers, build_options())
+    |> HTTPoison.post(body, process_request_headers(headers), build_options())
     |> handle_response
   end
 
   @spec delete_request(String.t, HTTPoison.Base.headers) :: response
   def delete_request(url, headers \\ []) do
     url
-    |> delete(headers, build_options())
+    |> HTTPoison.delete(process_request_headers(headers), build_options())
     |> handle_response
+  end
+
+  defp process_request_headers(headers) do
+    api_version()
+    |> default_headers()
+    |> Map.merge(Map.new(headers))
+    |> Enum.into([])
   end
 
   # #########################
@@ -88,7 +78,7 @@ defmodule Lob.Client do
   @spec handle_response({:ok | :error, Response.t | Error.t}) :: response
   defp handle_response({:ok, %{body: body, headers: headers, status_code: code}})
   when code >= 200 and code < 300 do
-    {:ok, body, headers}
+    {:ok, process_response_body(body), headers}
   end
 
   defp handle_response({:ok, %{body: body}}) do
@@ -97,6 +87,10 @@ defmodule Lob.Client do
 
   defp handle_response({:error, error = %Error{}}) do
     {:error, %{message: Error.message(error)}}
+  end
+
+  defp process_response_body(body) do
+    Parser.parse!(body, keys: :atoms)
   end
 
   @spec build_options(String.t) :: Keyword.t


### PR DESCRIPTION
In https://github.com/edgurgel/httpoison/commit/cd5f6b6 HTTPoison introduced a response type which collides with the response type defined in `lib/lob/client.ex` because we `use HTTPoison.Base`.

This came up because I wanted to relax the requirement of httpoison but couldn't due to the typespec conflict. I'll submit a second PR for that change.