### PR TITLE
chore(formatter): add formatter to build pipeline

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - mix coveralls.travis --max-cases 1
   - mix credo
   - mix dialyzer --halt-exit-status
+  - mix format --check-formatted
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@ language: elixir
 sudo: false
 
 elixir:
-  - '1.4.5'
-  - '1.5.3'
-  - '1.6.1'
+  - '1.8.2'
+  - '1.9.0'
 
 otp_release:
-  - '20.0'
+  - '22.0'
 
 env:
   - MIX_ENV="test"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,5 @@ Make sure you have Elixir 1.4 or greater installed. Copy and paste the following
 4. Push to the branch (`git push origin my-new-feature`).
 5. Make sure the tests pass (`mix coveralls.html`).
 6. Open up `cover/excoveralls.html` in your browser and add tests if required to meet the minimum coverage threshold.
-7. Create new Pull Request.
+7. Make sure the code is formatted (`mix format`).
+8. Create new Pull Request.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 use Mix.Config
 
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/lib/lob/address.ex
+++ b/lib/lob/address.ex
@@ -4,5 +4,4 @@ defmodule Lob.Address do
   """
 
   use Lob.ResourceBase, endpoint: "addresses", methods: [:create, :retrieve, :list, :delete]
-
 end

--- a/lib/lob/bank_account.ex
+++ b/lib/lob/bank_account.ex
@@ -5,11 +5,10 @@ defmodule Lob.BankAccount do
 
   use Lob.ResourceBase, endpoint: "bank_accounts", methods: [:create, :retrieve, :list, :delete]
 
-  @spec verify(String.t, map, map) :: Client.client_response
+  @spec verify(String.t(), map, map) :: Client.client_response()
   def verify(id, data, headers \\ %{}) do
     Client.post_request(verify_url(id), Util.build_body(data), Util.build_headers(headers))
   end
 
   defp verify_url(resource_id), do: "#{resource_url(resource_id)}/verify"
-
 end

--- a/lib/lob/check.ex
+++ b/lib/lob/check.ex
@@ -4,5 +4,4 @@ defmodule Lob.Check do
   """
 
   use Lob.ResourceBase, endpoint: "checks", methods: [:create, :retrieve, :list, :delete]
-
 end

--- a/lib/lob/client.ex
+++ b/lib/lob/client.ex
@@ -9,7 +9,7 @@ defmodule Lob.Client do
 
   use HTTPoison.Base
 
-  @client_version Mix.Project.config[:version]
+  @client_version Mix.Project.config()[:version]
 
   @type client_response :: {:ok, map, list} | {:error, map}
 
@@ -19,18 +19,18 @@ defmodule Lob.Client do
     """
 
     defexception message: """
-      The api_key setting is required to make requests to Lob.
-      Please configure :api_key in config.exs or set the LOB_API_KEY
-      environment variable.
+                   The api_key setting is required to make requests to Lob.
+                   Please configure :api_key in config.exs or set the LOB_API_KEY
+                   environment variable.
 
-      config :lob_elixir, api_key: API_KEY
-    """
+                   config :lob_elixir, api_key: API_KEY
+                 """
   end
 
-  @spec client_version :: String.t
+  @spec client_version :: String.t()
   def client_version, do: @client_version
 
-  @spec api_key(atom) :: String.t
+  @spec api_key(atom) :: String.t()
   def api_key(env_key \\ :api_key) do
     case Application.get_env(:lob_elixir, env_key, System.get_env("LOB_API_KEY")) || :not_found do
       :not_found -> raise MissingAPIKeyError
@@ -38,8 +38,9 @@ defmodule Lob.Client do
     end
   end
 
-  @spec api_version :: String.t | nil
-  def api_version, do: Application.get_env(:lob_elixir, :api_version, System.get_env("LOB_API_VERSION"))
+  @spec api_version :: String.t() | nil
+  def api_version,
+    do: Application.get_env(:lob_elixir, :api_version, System.get_env("LOB_API_VERSION"))
 
   # #########################
   # HTTPoison.Base callbacks
@@ -60,21 +61,21 @@ defmodule Lob.Client do
   # Client API
   # #########################
 
-  @spec get_request(String.t, HTTPoison.Base.headers) :: client_response
+  @spec get_request(String.t(), HTTPoison.Base.headers()) :: client_response
   def get_request(url, headers \\ []) do
     url
     |> get(headers, build_options())
     |> handle_response
   end
 
-  @spec post_request(String.t, {:multipart, list}, HTTPoison.Base.headers) :: client_response
+  @spec post_request(String.t(), {:multipart, list}, HTTPoison.Base.headers()) :: client_response
   def post_request(url, body, headers \\ []) do
     url
     |> post(body, headers, build_options())
     |> handle_response
   end
 
-  @spec delete_request(String.t, HTTPoison.Base.headers) :: client_response
+  @spec delete_request(String.t(), HTTPoison.Base.headers()) :: client_response
   def delete_request(url, headers \\ []) do
     url
     |> delete(headers, build_options())
@@ -85,9 +86,9 @@ defmodule Lob.Client do
   # Response handlers
   # #########################
 
-  @spec handle_response({:ok | :error, Response.t | Error.t}) :: client_response
+  @spec handle_response({:ok | :error, Response.t() | Error.t()}) :: client_response
   defp handle_response({:ok, %{body: body, headers: headers, status_code: code}})
-  when code >= 200 and code < 300 do
+       when code >= 200 and code < 300 do
     {:ok, body, headers}
   end
 
@@ -99,13 +100,17 @@ defmodule Lob.Client do
     {:error, %{message: Error.message(error)}}
   end
 
-  @spec build_options(String.t) :: Keyword.t
+  @spec build_options(String.t()) :: Keyword.t()
   defp build_options(api_key \\ api_key()) do
     [hackney: [basic_auth: {api_key, ""}], recv_timeout: :infinity]
   end
 
-  @spec default_headers(String.t | nil) :: %{String.t => String.t}
+  @spec default_headers(String.t() | nil) :: %{String.t() => String.t()}
   defp default_headers(nil), do: %{"User-Agent" => "Lob/v1 ElixirBindings/#{client_version()}"}
-  defp default_headers(api_version), do: %{"User-Agent" => "Lob/v1 ElixirBindings/#{client_version()}", "Lob-Version" => api_version}
 
+  defp default_headers(api_version),
+    do: %{
+      "User-Agent" => "Lob/v1 ElixirBindings/#{client_version()}",
+      "Lob-Version" => api_version
+    }
 end

--- a/lib/lob/intl_verification.ex
+++ b/lib/lob/intl_verification.ex
@@ -5,9 +5,8 @@ defmodule Lob.IntlVerification do
 
   use Lob.ResourceBase, endpoint: "intl_verifications", methods: []
 
-  @spec verify(map, map) :: Client.client_response
+  @spec verify(map, map) :: Client.client_response()
   def verify(data, headers \\ %{}) do
     Client.post_request(base_url(), Util.build_body(data), Util.build_headers(headers))
   end
-
 end

--- a/lib/lob/letter.ex
+++ b/lib/lob/letter.ex
@@ -4,5 +4,4 @@ defmodule Lob.Letter do
   """
 
   use Lob.ResourceBase, endpoint: "letters", methods: [:create, :retrieve, :list, :delete]
-
 end

--- a/lib/lob/postcard.ex
+++ b/lib/lob/postcard.ex
@@ -4,5 +4,4 @@ defmodule Lob.Postcard do
   """
 
   use Lob.ResourceBase, endpoint: "postcards", methods: [:create, :retrieve, :list, :delete]
-
 end

--- a/lib/lob/resource_base.ex
+++ b/lib/lob/resource_base.ex
@@ -14,9 +14,12 @@ defmodule Lob.ResourceBase do
       alias Lob.Client
 
       if :list in unquote(methods) do
-        @spec list(map, map) :: Client.client_response
+        @spec list(map, map) :: Client.client_response()
         def list(params \\ %{}, headers \\ %{}) do
-          Client.get_request("#{base_url()}?#{Util.build_query_string(params)}" , Util.build_headers(headers))
+          Client.get_request(
+            "#{base_url()}?#{Util.build_query_string(params)}",
+            Util.build_headers(headers)
+          )
         end
 
         @spec list!(map, map) :: {map, list} | no_return
@@ -29,12 +32,12 @@ defmodule Lob.ResourceBase do
       end
 
       if :retrieve in unquote(methods) do
-        @spec retrieve(String.t, map) :: Client.client_response
+        @spec retrieve(String.t(), map) :: Client.client_response()
         def retrieve(id, headers \\ %{}) do
           Client.get_request(resource_url(id), Util.build_headers(headers))
         end
 
-        @spec retrieve!(String.t, map) :: {map, list} | no_return
+        @spec retrieve!(String.t(), map) :: {map, list} | no_return
         def retrieve!(id, headers \\ %{}) do
           case retrieve(id, headers) do
             {:ok, body, headers} -> {body, headers}
@@ -44,7 +47,7 @@ defmodule Lob.ResourceBase do
       end
 
       if :create in unquote(methods) do
-        @spec create(map, map) :: Client.client_response
+        @spec create(map, map) :: Client.client_response()
         def create(data, headers \\ %{}) do
           Client.post_request(base_url(), Util.build_body(data), Util.build_headers(headers))
         end
@@ -59,12 +62,12 @@ defmodule Lob.ResourceBase do
       end
 
       if :delete in unquote(methods) do
-        @spec delete(String.t, map) :: Client.client_response
+        @spec delete(String.t(), map) :: Client.client_response()
         def delete(id, headers \\ %{}) do
           Client.delete_request(resource_url(id), Util.build_headers(headers))
         end
 
-        @spec delete!(String.t, map) :: {map, list} | no_return
+        @spec delete!(String.t(), map) :: {map, list} | no_return
         def delete!(id, headers \\ %{}) do
           case delete(id, headers) do
             {:ok, body, headers} -> {body, headers}
@@ -73,16 +76,14 @@ defmodule Lob.ResourceBase do
         end
       end
 
-      @spec base_url :: String.t
+      @spec base_url :: String.t()
       defp base_url, do: "#{api_host()}/#{unquote(endpoint)}"
 
-      @spec api_host :: String.t
+      @spec api_host :: String.t()
       defp api_host, do: Application.get_env(:lob_elixir, :api_host, @default_api_host)
 
-      @spec resource_url(String.t) :: String.t
+      @spec resource_url(String.t()) :: String.t()
       defp resource_url(resource_id), do: "#{base_url()}/#{resource_id}"
     end
-
   end
-
 end

--- a/lib/lob/us_autocompletion.ex
+++ b/lib/lob/us_autocompletion.ex
@@ -5,7 +5,7 @@ defmodule Lob.USAutocompletion do
 
   use Lob.ResourceBase, endpoint: "us_autocompletions", methods: []
 
-  @spec autocomplete(map, map) :: Client.client_response
+  @spec autocomplete(map, map) :: Client.client_response()
   def autocomplete(data, headers \\ %{}) do
     Client.post_request(base_url(), Util.build_body(data), Util.build_headers(headers))
   end

--- a/lib/lob/us_verification.ex
+++ b/lib/lob/us_verification.ex
@@ -5,9 +5,8 @@ defmodule Lob.USVerification do
 
   use Lob.ResourceBase, endpoint: "us_verifications", methods: []
 
-  @spec verify(map, map) :: Client.client_response
+  @spec verify(map, map) :: Client.client_response()
   def verify(data, headers \\ %{}) do
     Client.post_request(base_url(), Util.build_body(data), Util.build_headers(headers))
   end
-
 end

--- a/lib/lob/us_zip_lookup.ex
+++ b/lib/lob/us_zip_lookup.ex
@@ -5,9 +5,8 @@ defmodule Lob.USZipLookup do
 
   use Lob.ResourceBase, endpoint: "us_zip_lookups", methods: []
 
-  @spec lookup(map, map) :: Client.client_response
+  @spec lookup(map, map) :: Client.client_response()
   def lookup(data, headers \\ %{}) do
     Client.post_request(base_url(), Util.build_body(data), Util.build_headers(headers))
   end
-
 end

--- a/lib/lob/util.ex
+++ b/lib/lob/util.ex
@@ -10,7 +10,7 @@ defmodule Lob.Util do
     iex> Lob.Util.build_query_string(%{count: 1, include: ["total_count"], metadata: %{name: "Larry"}})
     "count=1&include%5B%5D=total_count&metadata%5Bname%5D=Larry"
   """
-  @spec build_query_string(map) :: String.t
+  @spec build_query_string(map) :: String.t()
   def build_query_string(params) when is_map(params) do
     params
     |> Enum.reduce([], &(&2 ++ transform_argument(&1)))
@@ -38,10 +38,10 @@ defmodule Lob.Util do
     iex> Lob.Util.build_headers(%{"Idempotency-Key" => "abc123", "Lob-Version" => "2017-11-08"})
     [{"Idempotency-Key", "abc123"}, {"Lob-Version", "2017-11-08"}]
   """
-  @spec build_headers(map) :: HTTPoison.Base.headers
+  @spec build_headers(map) :: HTTPoison.Base.headers()
   def build_headers(headers) do
     headers
-    |> Enum.to_list
+    |> Enum.to_list()
     |> Enum.map(fn {k, v} -> {to_string(k), to_string(v)} end)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Lob.Mixfile do
       version: "1.1.1",
       elixir: "~> 1.4",
       preferred_cli_env: ["coveralls.html": :test],
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       description: "Lob Elixir Library",
       package: package(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Lob.Mixfile do
     [
       app: :lob_elixir,
       version: "1.1.1",
-      elixir: "~> 1.4",
+      elixir: "~> 1.8",
       preferred_cli_env: ["coveralls.html": :test],
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/test/lob/address_test.exs
+++ b/test/lob/address_test.exs
@@ -19,7 +19,6 @@ defmodule Lob.AddressTest do
   end
 
   describe "list/2" do
-
     test "lists addresses" do
       {:ok, addresses, _headers} = Address.list()
       assert addresses.object == "list"
@@ -39,22 +38,18 @@ defmodule Lob.AddressTest do
       {:ok, addresses, _headers} = Address.list(%{metadata: %{foo: "bar"}})
       assert addresses.count == 1
     end
-
   end
 
   describe "retrieve/2" do
-
     test "retrieves an address", %{sample_address: sample_address} do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
       {:ok, retrieved_address, _headers} = Address.retrieve(created_address.id)
       assert retrieved_address.name == created_address.name
     end
-
   end
 
   describe "create/2" do
-
     test "creates an address", %{sample_address: sample_address} do
       {:ok, created_address, headers} = Address.create(sample_address)
 
@@ -66,16 +61,14 @@ defmodule Lob.AddressTest do
       {:ok, created_address, headers} =
         sample_address
         |> Map.merge(%{metadata: %{key: "value"}})
-        |> Address.create
+        |> Address.create()
 
       assert created_address.name == String.upcase(sample_address.name)
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
-
   end
 
   describe "delete/2" do
-
     test "deletes an address", %{sample_address: sample_address} do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
@@ -83,7 +76,5 @@ defmodule Lob.AddressTest do
       assert deleted_address.id == created_address.id
       assert deleted_address.deleted == true
     end
-
   end
-
 end

--- a/test/lob/bank_account_test.exs
+++ b/test/lob/bank_account_test.exs
@@ -15,7 +15,6 @@ defmodule Lob.BankAccountTest do
   end
 
   describe "list/2" do
-
     test "lists bank accounts" do
       {:ok, bank_accounts, _headers} = BankAccount.list()
       assert bank_accounts.object == "list"
@@ -35,22 +34,18 @@ defmodule Lob.BankAccountTest do
       {:ok, bank_accounts, _headers} = BankAccount.list(%{metadata: %{foo: "bar"}})
       assert bank_accounts.count == 1
     end
-
   end
 
   describe "retrieve/2" do
-
     test "retrieves a bank account", %{sample_bank_account: sample_bank_account} do
       {:ok, created_bank_account, _headers} = BankAccount.create(sample_bank_account)
 
       {:ok, retrieved_bank_account, _headers} = BankAccount.retrieve(created_bank_account.id)
       assert retrieved_bank_account.account_number == created_bank_account.account_number
     end
-
   end
 
   describe "create/2" do
-
     test "creates a bank account", %{sample_bank_account: sample_bank_account} do
       {:ok, created_bank_account, headers} = BankAccount.create(sample_bank_account)
 
@@ -62,16 +57,14 @@ defmodule Lob.BankAccountTest do
       {:ok, created_bank_account, headers} =
         sample_bank_account
         |> Map.merge(%{metadata: %{key: "value"}})
-        |> BankAccount.create
+        |> BankAccount.create()
 
       assert created_bank_account.account_number == sample_bank_account.account_number
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
-
   end
 
   describe "delete/2" do
-
     test "deletes a bank account", %{sample_bank_account: sample_bank_account} do
       {:ok, created_bank_account, _headers} = BankAccount.create(sample_bank_account)
 
@@ -79,19 +72,17 @@ defmodule Lob.BankAccountTest do
       assert deleted_bank_account.id == created_bank_account.id
       assert deleted_bank_account.deleted == true
     end
-
   end
 
   describe "verify/3" do
-
     test "verifies a bank account", %{sample_bank_account: sample_bank_account} do
       {:ok, created_bank_account, _headers} = BankAccount.create(sample_bank_account)
 
-      {:ok, verified_bank_account, _headers} = BankAccount.verify(created_bank_account.id, %{amounts: [12, 34]})
+      {:ok, verified_bank_account, _headers} =
+        BankAccount.verify(created_bank_account.id, %{amounts: [12, 34]})
+
       assert created_bank_account.id == verified_bank_account.id
       assert verified_bank_account.verified == true
     end
-
   end
-
 end

--- a/test/lob/check_test.exs
+++ b/test/lob/check_test.exs
@@ -25,7 +25,7 @@ defmodule Lob.CheckTest do
     }
 
     sample_check = %{
-      description: "Library Test Check #{DateTime.utc_now |> DateTime.to_string}",
+      description: "Library Test Check #{DateTime.utc_now() |> DateTime.to_string()}",
       amount: 100
     }
 
@@ -37,7 +37,6 @@ defmodule Lob.CheckTest do
   end
 
   describe "list/2" do
-
     test "lists checks" do
       {:ok, checks, _headers} = Check.list()
       assert checks.object == "list"
@@ -57,12 +56,14 @@ defmodule Lob.CheckTest do
       {:ok, checks, _headers} = Check.list(%{metadata: %{foo: "bar"}})
       assert checks.count == 1
     end
-
   end
 
   describe "retrieve/2" do
-
-    test "retrieves a check", %{sample_address: sample_address, sample_bank_account: sample_bank_account, sample_check: sample_check} do
+    test "retrieves a check", %{
+      sample_address: sample_address,
+      sample_bank_account: sample_bank_account,
+      sample_check: sample_check
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
       {:ok, verified_bank_account, _headers} = create_and_verify_bank_account(sample_bank_account)
 
@@ -78,12 +79,14 @@ defmodule Lob.CheckTest do
       {:ok, retrieved_check, _headers} = Check.retrieve(created_check.id)
       assert retrieved_check.description == created_check.description
     end
-
   end
 
   describe "create/2" do
-
-    test "creates a check with address_id", %{sample_address: sample_address, sample_bank_account: sample_bank_account, sample_check: sample_check} do
+    test "creates a check with address_id", %{
+      sample_address: sample_address,
+      sample_bank_account: sample_bank_account,
+      sample_check: sample_check
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
       {:ok, verified_bank_account, _headers} = create_and_verify_bank_account(sample_bank_account)
 
@@ -100,7 +103,11 @@ defmodule Lob.CheckTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a check with address params", %{sample_check: sample_check, sample_bank_account: sample_bank_account, sample_address: sample_address} do
+    test "creates a check with address params", %{
+      sample_check: sample_check,
+      sample_bank_account: sample_bank_account,
+      sample_address: sample_address
+    } do
       {:ok, verified_bank_account, _headers} = create_and_verify_bank_account(sample_bank_account)
 
       {:ok, created_check, headers} =
@@ -116,7 +123,11 @@ defmodule Lob.CheckTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a check with logo, attachment and check bottom as URL", %{sample_address: sample_address, sample_bank_account: sample_bank_account, sample_check: sample_check} do
+    test "creates a check with logo, attachment and check bottom as URL", %{
+      sample_address: sample_address,
+      sample_bank_account: sample_bank_account,
+      sample_check: sample_check
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
       {:ok, verified_bank_account, _headers} = create_and_verify_bank_account(sample_bank_account)
 
@@ -128,7 +139,8 @@ defmodule Lob.CheckTest do
           bank_account: verified_bank_account.id,
           amount: 42,
           logo: "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/check_logo.png",
-          check_bottom: "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/us_letter_1pg.pdf",
+          check_bottom:
+            "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/us_letter_1pg.pdf",
           attachment: "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/us_letter_1pg.pdf"
         })
 
@@ -136,7 +148,11 @@ defmodule Lob.CheckTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a check with logo as PNG and attachment and check bottom as PDF", %{sample_address: sample_address, sample_bank_account: sample_bank_account, sample_check: sample_check} do
+    test "creates a check with logo as PNG and attachment and check bottom as PDF", %{
+      sample_address: sample_address,
+      sample_bank_account: sample_bank_account,
+      sample_check: sample_check
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
       {:ok, verified_bank_account, _headers} = create_and_verify_bank_account(sample_bank_account)
 
@@ -156,42 +172,54 @@ defmodule Lob.CheckTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a check with an idempotency key", %{sample_address: sample_address, sample_bank_account: sample_bank_account, sample_check: sample_check} do
+    test "creates a check with an idempotency key", %{
+      sample_address: sample_address,
+      sample_bank_account: sample_bank_account,
+      sample_check: sample_check
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
       {:ok, verified_bank_account, _headers} = create_and_verify_bank_account(sample_bank_account)
 
       idempotency_key = UUID.uuid4()
 
       {:ok, created_check, _headers} =
-        Check.create(%{
-          description: sample_check.description,
-          to: created_address.id,
-          from: created_address.id,
-          bank_account: verified_bank_account.id,
-          amount: 42
-        }, %{
-          "Idempotency-Key" => idempotency_key
-        })
+        Check.create(
+          %{
+            description: sample_check.description,
+            to: created_address.id,
+            from: created_address.id,
+            bank_account: verified_bank_account.id,
+            amount: 42
+          },
+          %{
+            "Idempotency-Key" => idempotency_key
+          }
+        )
 
       {:ok, duplicated_postcard, _headers} =
-        Check.create(%{
-          description: "Duplicated Check",
-          to: created_address.id,
-          from: created_address.id,
-          bank_account: verified_bank_account.id,
-          amount: 42
-        }, %{
-          "Idempotency-Key" => idempotency_key
-        })
+        Check.create(
+          %{
+            description: "Duplicated Check",
+            to: created_address.id,
+            from: created_address.id,
+            bank_account: verified_bank_account.id,
+            amount: 42
+          },
+          %{
+            "Idempotency-Key" => idempotency_key
+          }
+        )
 
       assert created_check.description == duplicated_postcard.description
     end
-
   end
 
   describe "delete/2" do
-
-    test "deletes a check", %{sample_address: sample_address, sample_bank_account: sample_bank_account, sample_check: sample_check} do
+    test "deletes a check", %{
+      sample_address: sample_address,
+      sample_bank_account: sample_bank_account,
+      sample_check: sample_check
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
       {:ok, verified_bank_account, _headers} = create_and_verify_bank_account(sample_bank_account)
 
@@ -204,11 +232,10 @@ defmodule Lob.CheckTest do
           amount: 42
         })
 
-        {:ok, deleted_check, _headers} = Check.delete(created_check.id)
-        assert deleted_check.id == created_check.id
-        assert deleted_check.deleted == true
+      {:ok, deleted_check, _headers} = Check.delete(created_check.id)
+      assert deleted_check.id == created_check.id
+      assert deleted_check.deleted == true
     end
-
   end
 
   defp create_and_verify_bank_account(payload) do
@@ -218,5 +245,4 @@ defmodule Lob.CheckTest do
     |> Map.get(:id)
     |> BankAccount.verify(%{amounts: [12, 34]})
   end
-
 end

--- a/test/lob/client_test.exs
+++ b/test/lob/client_test.exs
@@ -6,27 +6,22 @@ defmodule Lob.ClientTest do
   alias Plug.Conn
 
   setup do
-    bypass = Bypass.open
+    bypass = Bypass.open()
     {:ok, bypass: bypass}
   end
 
   describe "api_key/1" do
-
     test "raises MissingAPIKeyError if no API key is found" do
-
       assert_raise(MissingAPIKeyError, fn ->
         api_key = System.get_env("LOB_API_KEY")
         System.delete_env("LOB_API_KEY")
         Client.api_key(nil)
         System.put_env("LOB_API_KEY", api_key)
       end)
-
     end
-
   end
 
   describe "get_request/2" do
-
     test "handles 2XX responses", %{bypass: bypass} do
       response_body = %{
         data: %{
@@ -34,11 +29,11 @@ defmodule Lob.ClientTest do
         }
       }
 
-      Bypass.expect bypass, fn conn ->
+      Bypass.expect(bypass, fn conn ->
         conn
         |> Conn.put_resp_header("HeaderKey", "HeaderValue")
         |> Conn.resp(203, Poison.encode!(response_body))
-      end
+      end)
 
       {:ok, body, headers} = Client.get_request(endpoint_url(bypass.port))
       assert response_body == body
@@ -53,9 +48,9 @@ defmodule Lob.ClientTest do
         }
       }
 
-      Bypass.expect bypass, fn conn ->
+      Bypass.expect(bypass, fn conn ->
         Conn.resp(conn, 404, Poison.encode!(response_body))
-      end
+      end)
 
       {:error, error} = Client.get_request(endpoint_url(bypass.port))
       assert error == response_body.error
@@ -66,9 +61,7 @@ defmodule Lob.ClientTest do
       {:error, %{message: error}} = Client.get_request(endpoint_url(bypass.port))
       assert error == ":econnrefused"
     end
-
   end
 
   defp endpoint_url(port), do: "http://localhost:#{port}"
-
 end

--- a/test/lob/intl_verification_test.exs
+++ b/test/lob/intl_verification_test.exs
@@ -16,12 +16,9 @@ defmodule Lob.IntlVerificationTest do
   end
 
   describe "verify/2" do
-
     test "returns a 403 in test mode", %{sample_address: sample_address} do
       {:error, message} = IntlVerification.verify(sample_address)
       assert message.status_code == 403
     end
-
   end
-
 end

--- a/test/lob/letter_test.exs
+++ b/test/lob/letter_test.exs
@@ -17,7 +17,7 @@ defmodule Lob.LetterTest do
     }
 
     sample_letter = %{
-      description: "Library Test Letter #{DateTime.utc_now |> DateTime.to_string}"
+      description: "Library Test Letter #{DateTime.utc_now() |> DateTime.to_string()}"
     }
 
     %{
@@ -27,7 +27,6 @@ defmodule Lob.LetterTest do
   end
 
   describe "list/2" do
-
     test "lists letters" do
       {:ok, letters, _headers} = Letter.list()
       assert letters.object == "list"
@@ -47,11 +46,9 @@ defmodule Lob.LetterTest do
       {:ok, letters, _headers} = Letter.list(%{metadata: %{foo: "bar"}})
       assert letters.count == 1
     end
-
   end
 
   describe "retrieve/2" do
-
     test "retrieves a letter", %{sample_address: sample_address, sample_letter: sample_letter} do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
@@ -67,12 +64,13 @@ defmodule Lob.LetterTest do
       {:ok, retrieved_letter, _headers} = Letter.retrieve(created_letter.id)
       assert retrieved_letter.description == created_letter.description
     end
-
   end
 
   describe "create/2" do
-
-    test "creates a letter with address_id", %{sample_address: sample_address, sample_letter: sample_letter} do
+    test "creates a letter with address_id", %{
+      sample_address: sample_address,
+      sample_letter: sample_letter
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
       {:ok, created_letter, headers} =
@@ -88,7 +86,10 @@ defmodule Lob.LetterTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a letter with address params", %{sample_letter: sample_letter, sample_address: sample_address} do
+    test "creates a letter with address params", %{
+      sample_letter: sample_letter,
+      sample_address: sample_address
+    } do
       {:ok, created_letter, headers} =
         Letter.create(%{
           description: sample_letter.description,
@@ -102,7 +103,10 @@ defmodule Lob.LetterTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a letter with file as PDF", %{sample_address: sample_address, sample_letter: sample_letter} do
+    test "creates a letter with file as PDF", %{
+      sample_address: sample_address,
+      sample_letter: sample_letter
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
       {:ok, created_letter, headers} =
@@ -118,39 +122,46 @@ defmodule Lob.LetterTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a letter with an idempotency key", %{sample_address: sample_address, sample_letter: sample_letter} do
+    test "creates a letter with an idempotency key", %{
+      sample_address: sample_address,
+      sample_letter: sample_letter
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
       idempotency_key = UUID.uuid4()
 
       {:ok, created_letter, _headers} =
-        Letter.create(%{
-          description: sample_letter.description,
-          to: created_address.id,
-          from: created_address.id,
-          color: true,
-          file: %{local_path: "test/assets/8.5x11.pdf"}
-        }, %{
-          "Idempotency-Key" => idempotency_key
-        })
+        Letter.create(
+          %{
+            description: sample_letter.description,
+            to: created_address.id,
+            from: created_address.id,
+            color: true,
+            file: %{local_path: "test/assets/8.5x11.pdf"}
+          },
+          %{
+            "Idempotency-Key" => idempotency_key
+          }
+        )
 
       {:ok, duplicated_letter, _headers} =
-        Letter.create(%{
-          description: "Duplicated Letter",
-          to: created_address.id,
-          from: created_address.id,
-          color: true,
-          file: %{local_path: "test/assets/8.5x11.pdf"}
-        }, %{
-          "Idempotency-Key" => idempotency_key
-        })
+        Letter.create(
+          %{
+            description: "Duplicated Letter",
+            to: created_address.id,
+            from: created_address.id,
+            color: true,
+            file: %{local_path: "test/assets/8.5x11.pdf"}
+          },
+          %{
+            "Idempotency-Key" => idempotency_key
+          }
+        )
 
       assert created_letter.description == duplicated_letter.description
     end
-
   end
 
   describe "delete/2" do
-
     test "deletes a letter", %{sample_address: sample_address, sample_letter: sample_letter} do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
@@ -163,11 +174,9 @@ defmodule Lob.LetterTest do
           file: %{local_path: "test/assets/8.5x11.pdf"}
         })
 
-        {:ok, deleted_letter, _headers} = Letter.delete(created_letter.id)
-        assert deleted_letter.id == created_letter.id
-        assert deleted_letter.deleted == true
+      {:ok, deleted_letter, _headers} = Letter.delete(created_letter.id)
+      assert deleted_letter.id == created_letter.id
+      assert deleted_letter.deleted == true
     end
-
   end
-
 end

--- a/test/lob/postcard_test.exs
+++ b/test/lob/postcard_test.exs
@@ -17,7 +17,7 @@ defmodule Lob.PostcardTest do
     }
 
     sample_postcard = %{
-      description: "Library Test Postcard #{DateTime.utc_now |> DateTime.to_string}",
+      description: "Library Test Postcard #{DateTime.utc_now() |> DateTime.to_string()}",
       back: "<h1>Sample postcard back</h1>"
     }
 
@@ -28,7 +28,6 @@ defmodule Lob.PostcardTest do
   end
 
   describe "list/2" do
-
     test "lists postcards" do
       {:ok, postcards, _headers} = Postcard.list()
       assert postcards.object == "list"
@@ -48,12 +47,13 @@ defmodule Lob.PostcardTest do
       {:ok, postcards, _headers} = Postcard.list(%{metadata: %{foo: "bar"}})
       assert postcards.count == 1
     end
-
   end
 
   describe "retrieve/2" do
-
-    test "retrieves a postcard", %{sample_address: sample_address, sample_postcard: sample_postcard} do
+    test "retrieves a postcard", %{
+      sample_address: sample_address,
+      sample_postcard: sample_postcard
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
       {:ok, created_postcard, _headers} =
@@ -67,12 +67,13 @@ defmodule Lob.PostcardTest do
       {:ok, retrieved_postcard, _headers} = Postcard.retrieve(created_postcard.id)
       assert retrieved_postcard.description == created_postcard.description
     end
-
   end
 
   describe "create/2" do
-
-    test "creates a postcard with address_id", %{sample_address: sample_address, sample_postcard: sample_postcard} do
+    test "creates a postcard with address_id", %{
+      sample_address: sample_address,
+      sample_postcard: sample_postcard
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
       {:ok, created_postcard, headers} =
@@ -87,7 +88,10 @@ defmodule Lob.PostcardTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a postcard with to address params", %{sample_postcard: sample_postcard, sample_address: sample_address} do
+    test "creates a postcard with to address params", %{
+      sample_postcard: sample_postcard,
+      sample_address: sample_address
+    } do
       {:ok, created_postcard, headers} =
         Postcard.create(%{
           description: sample_postcard.description,
@@ -100,7 +104,11 @@ defmodule Lob.PostcardTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a postcard with from address params", %{sample_address: sample_address, sample_postcard: sample_postcard, sample_address: sample_address} do
+    test "creates a postcard with from address params", %{
+      sample_address: sample_address,
+      sample_postcard: sample_postcard,
+      sample_address: sample_address
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
       {:ok, created_postcard, headers} =
@@ -116,7 +124,10 @@ defmodule Lob.PostcardTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a postcard with front and back as urls", %{sample_address: sample_address, sample_postcard: sample_postcard} do
+    test "creates a postcard with front and back as urls", %{
+      sample_address: sample_address,
+      sample_postcard: sample_postcard
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
       {:ok, created_postcard, headers} =
@@ -131,7 +142,10 @@ defmodule Lob.PostcardTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a postcard with front and back as PDFs", %{sample_address: sample_address, sample_postcard: sample_postcard} do
+    test "creates a postcard with front and back as PDFs", %{
+      sample_address: sample_address,
+      sample_postcard: sample_postcard
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
       {:ok, created_postcard, headers} =
@@ -146,37 +160,44 @@ defmodule Lob.PostcardTest do
       assert Enum.member?(headers, {"X-Rate-Limit-Limit", "150"})
     end
 
-    test "creates a postcard with an idempotency key", %{sample_address: sample_address, sample_postcard: sample_postcard} do
+    test "creates a postcard with an idempotency key", %{
+      sample_address: sample_address,
+      sample_postcard: sample_postcard
+    } do
       {:ok, created_address, _headers} = Address.create(sample_address)
       idempotency_key = UUID.uuid4()
 
       {:ok, created_postcard, _headers} =
-        Postcard.create(%{
-          description: sample_postcard.description,
-          to: created_address.id,
-          front: %{local_path: "test/assets/postcardfront.pdf"},
-          back: %{local_path: "test/assets/postcardback.pdf"}
-        }, %{
-          "Idempotency-Key" => idempotency_key
-        })
+        Postcard.create(
+          %{
+            description: sample_postcard.description,
+            to: created_address.id,
+            front: %{local_path: "test/assets/postcardfront.pdf"},
+            back: %{local_path: "test/assets/postcardback.pdf"}
+          },
+          %{
+            "Idempotency-Key" => idempotency_key
+          }
+        )
 
       {:ok, duplicated_postcard, _headers} =
-        Postcard.create(%{
-          description: "Duplicated Postcard",
-          to: created_address.id,
-          front: %{local_path: "test/assets/postcardfront.pdf"},
-          back: %{local_path: "test/assets/postcardback.pdf"}
-        }, %{
-          "Idempotency-Key" => idempotency_key
-        })
+        Postcard.create(
+          %{
+            description: "Duplicated Postcard",
+            to: created_address.id,
+            front: %{local_path: "test/assets/postcardfront.pdf"},
+            back: %{local_path: "test/assets/postcardback.pdf"}
+          },
+          %{
+            "Idempotency-Key" => idempotency_key
+          }
+        )
 
       assert created_postcard.description == duplicated_postcard.description
     end
-
   end
 
   describe "delete/2" do
-
     test "deletes a postcard", %{sample_address: sample_address, sample_postcard: sample_postcard} do
       {:ok, created_address, _headers} = Address.create(sample_address)
 
@@ -188,11 +209,9 @@ defmodule Lob.PostcardTest do
           back: "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/pc_4x6_back.pdf"
         })
 
-        {:ok, deleted_postcard, _headers} = Postcard.delete(created_postcard.id)
-        assert deleted_postcard.id == created_postcard.id
-        assert deleted_postcard.deleted == true
+      {:ok, deleted_postcard, _headers} = Postcard.delete(created_postcard.id)
+      assert deleted_postcard.id == created_postcard.id
+      assert deleted_postcard.deleted == true
     end
-
   end
-
 end

--- a/test/lob/us_autocompletion_test.exs
+++ b/test/lob/us_autocompletion_test.exs
@@ -4,7 +4,6 @@ defmodule Lob.USAutocompletionTest do
   alias Lob.USAutocompletion
 
   describe "autocomplete/2" do
-
     test "autocompletes a US Address" do
       payload = %{
         address_prefix: "185 BER",
@@ -21,7 +20,5 @@ defmodule Lob.USAutocompletionTest do
       assert result.suggestions |> List.first() |> Map.get(:primary_line) ==
                "TEST KEYS DO NOT AUTOCOMPLETE US ADDRESSES"
     end
-
   end
-
 end

--- a/test/lob/us_verification_test.exs
+++ b/test/lob/us_verification_test.exs
@@ -16,15 +16,16 @@ defmodule Lob.USVerificationTest do
   end
 
   describe "verify/2" do
-
     test "verifies a US address", %{sample_address: sample_address} do
       {:ok, verified_address, _headers} = USVerification.verify(sample_address)
 
       assert verified_address.recipient == "TEST KEYS DO NOT VERIFY ADDRESSES"
-      assert verified_address.primary_line == "SET `primary_line` TO 'deliverable' and `zip_code` to '11111' TO SIMULATE AN ADDRESS"
-      assert verified_address.secondary_line == "SEE https://www.lob.com/docs#us-verification-test-environment FOR MORE INFO"
+
+      assert verified_address.primary_line ==
+               "SET `primary_line` TO 'deliverable' and `zip_code` to '11111' TO SIMULATE AN ADDRESS"
+
+      assert verified_address.secondary_line ==
+               "SEE https://www.lob.com/docs#us-verification-test-environment FOR MORE INFO"
     end
-
   end
-
 end

--- a/test/lob/us_zip_lookup_test.exs
+++ b/test/lob/us_zip_lookup_test.exs
@@ -4,7 +4,6 @@ defmodule Lob.USZipLookupTest do
   alias Lob.USZipLookup
 
   describe "lookup/2" do
-
     test "lookup a US zip code" do
       zip_code = "94107"
 
@@ -14,7 +13,5 @@ defmodule Lob.USZipLookupTest do
       assert result.zip_code_type == "standard"
       assert length(result.cities) == 1
     end
-
   end
-
 end

--- a/test/lob/util_test.exs
+++ b/test/lob/util_test.exs
@@ -1,6 +1,4 @@
 defmodule Lob.UtilTest do
-
   use ExUnit.Case
   doctest Lob.Util
-
 end


### PR DESCRIPTION
### Changes

- [x] Adds Elixir formatter to the `.travis.yml` build pipeline.
- [x] Formats all existing files.
- [x] Updates Elixir version to 1.8 (since the formatter requires >= 1.6, and having updated versions is nice).
- [x] Yeet.