### PR TITLE
feat(config): support runtime config with Confex

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ config :lob_elixir,
   api_key: "your_api_key"
 ```
 
+The `{:system, "ENV_VAR"}` syntax is also supported, allowing the API key to be fetched at runtime. For example, if the API key is stored in an environment variable named `LOB_KEY`, the library could be configured with:
+
+```elixir
+# Configuring an API key with configs
+config :lob_elixir,
+  api_key: {:system, "LOB_KEY"}
+```
+
 Similarly, the library allows users to optionally configure the API version through the `:api_version` config. If that is not present, it will look for the `LOB_API_VERSION` environment variable.
 
 ```elixir
@@ -80,6 +88,6 @@ Then view the report at `cover/excoveralls.html`.
 
 =======================
 
-Copyright &copy; 2018 Lob.com
+Copyright &copy; 2019 Lob.com
 
 Released under the MIT License, which can be found in the repository in [`LICENSE.txt`](LICENSE.txt).

--- a/lib/lob/client.ex
+++ b/lib/lob/client.ex
@@ -32,7 +32,7 @@ defmodule Lob.Client do
 
   @spec api_key(atom) :: String.t
   def api_key(env_key \\ :api_key) do
-    case Application.get_env(:lob_elixir, env_key, System.get_env("LOB_API_KEY")) || :not_found do
+    case Confex.get_env(:lob_elixir, env_key, System.get_env("LOB_API_KEY")) || :not_found do
       :not_found -> raise MissingAPIKeyError
       value -> value
     end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Lob.Mixfile do
       version: "1.1.1",
       elixir: "~> 1.4",
       preferred_cli_env: ["coveralls.html": :test],
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       description: "Lob Elixir Library",
       package: package(),
@@ -33,6 +33,7 @@ defmodule Lob.Mixfile do
   defp deps do
     [
       {:bypass, "~> 0.8", only: :test},
+      {:confex, "~> 3.4.0"},
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5.1", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.7.4", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "bypass": {:hex, :bypass, "0.8.1", "16d409e05530ece4a72fabcf021a3e5c7e15dcc77f911423196a0c551f2a15ca", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "confex": {:hex, :confex, "3.4.0", "8b1c3cc7a93320291abb31223a178df19d7f722ee816c05a8070c8c9a054560d", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
### Changes

Includes `Confex` to allow us to configure the Lob Client with a `{:system, "ENV_VAR"}` tuple.